### PR TITLE
PHP7.4のnull等への添字アクセスで警告が出るようになったので対応

### DIFF
--- a/src/QdsmtpBase.php
+++ b/src/QdsmtpBase.php
@@ -43,6 +43,9 @@ class QdsmtpBase extends QdsmtpError
 	var $always_notify_success = false;
 
 	function __construct( $param = null ){
+        if (is_null($param)) {
+            return;
+        }
 		if( !is_null( $param[0] ) && is_bool( $param[0] ) ){
 			$this->continue = $continue;
 		}


### PR DESCRIPTION
### 対応

コンストラクタにnullだった場合に早期リターンする処理を追加